### PR TITLE
Hide MacVIM after the test suite has finished running

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
+    VIM.command("silent maca hide:")
     VIM.kill
   end
 end


### PR DESCRIPTION
This pull request ensures that after the test suite has run, the MacVIM instance hides itself and the focus returns the previous process (Terminal or iTerm for e.g.)